### PR TITLE
Sqs producer without receipts

### DIFF
--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -73,7 +73,9 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl true
-  def delete_messages(receipts, opts) do
+  def delete_messages(messages, opts) do
+    receipts = Enum.map(messages, &extract_message_receipt/1)
+
     opts.queue_name
     |> ExAws.SQS.delete_message_batch(receipts)
     |> ExAws.request(opts.config)
@@ -98,6 +100,11 @@ defmodule BroadwaySQS.ExAwsClient do
   defp put_max_number_of_messages(receive_messages_opts, total_demand) do
     max_number_of_messages = min(total_demand, receive_messages_opts[:max_number_of_messages])
     Keyword.put(receive_messages_opts, :max_number_of_messages, max_number_of_messages)
+  end
+
+  defp extract_message_receipt(message) do
+    {_, %{receipt: receipt}} = message.acknowledger
+    receipt
   end
 
   defp validate(opts, key, default \\ nil) when is_list(opts) do

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -82,7 +82,7 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   defp delete_messages(messages) do
-    [%Message{acknowledger: {_, %{sqs_client: {_, opts}}}} | _] = messages
+    [%Message{acknowledger: {_, %{sqs_client_opts: opts}}} | _] = messages
     receipts = Enum.map(messages, &extract_message_receipt/1)
 
     opts.queue_name
@@ -94,7 +94,7 @@ defmodule BroadwaySQS.ExAwsClient do
     Enum.map(body.messages, fn message ->
       ack_data = %{
         receipt: %{id: message.message_id, receipt_handle: message.receipt_handle},
-        sqs_client: {__MODULE__, opts}
+        sqs_client_opts: opts
       }
 
       %Message{data: message.body, acknowledger: {__MODULE__, ack_data}}

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -42,11 +42,13 @@ defmodule BroadwaySQS.ExAwsClient do
 
   """
 
+  alias Broadway.{Message, Acknowledger}
+
   @behaviour BroadwaySQS.SQSClient
+  @behaviour Acknowledger
 
   @default_max_number_of_messages 10
-
-  alias Broadway.Message
+  @max_num_messages_allowed_by_aws 10
 
   @impl true
   def init(opts) do
@@ -63,17 +65,24 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl true
-  def receive_messages(demand, opts, ack_module) do
+  def receive_messages(demand, opts) do
     receive_messages_opts = put_max_number_of_messages(opts.receive_messages_opts, demand)
 
     opts.queue_name
     |> ExAws.SQS.receive_message(receive_messages_opts)
     |> ExAws.request(opts.config)
-    |> wrap_received_messages(opts, ack_module)
+    |> wrap_received_messages(opts)
   end
 
   @impl true
-  def delete_messages(messages, opts) do
+  def ack(successful, _failed) do
+    successful
+    |> Enum.chunk_every(@max_num_messages_allowed_by_aws)
+    |> Enum.each(&delete_messages/1)
+  end
+
+  defp delete_messages(messages) do
+    [%Message{acknowledger: {_, %{sqs_client: {_, opts}}}} | _] = messages
     receipts = Enum.map(messages, &extract_message_receipt/1)
 
     opts.queue_name
@@ -81,18 +90,18 @@ defmodule BroadwaySQS.ExAwsClient do
     |> ExAws.request(opts.config)
   end
 
-  defp wrap_received_messages({:ok, %{body: body}}, opts, ack_module) do
+  defp wrap_received_messages({:ok, %{body: body}}, opts) do
     Enum.map(body.messages, fn message ->
       ack_data = %{
         receipt: %{id: message.message_id, receipt_handle: message.receipt_handle},
         sqs_client: {__MODULE__, opts}
       }
 
-      %Message{data: message.body, acknowledger: {ack_module, ack_data}}
+      %Message{data: message.body, acknowledger: {__MODULE__, ack_data}}
     end)
   end
 
-  defp wrap_received_messages({:error, reason}, _, _) do
+  defp wrap_received_messages({:error, reason}, _) do
     # TODO: Treat errors properly
     IO.warn("Unable to fetch events from AWS. Reason: #{inspect(reason)}")
   end

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -63,8 +63,8 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl true
-  def receive_messages(total_demand, opts, ack_module) do
-    receive_messages_opts = put_max_number_of_messages(opts.receive_messages_opts, total_demand)
+  def receive_messages(demand, opts, ack_module) do
+    receive_messages_opts = put_max_number_of_messages(opts.receive_messages_opts, demand)
 
     opts.queue_name
     |> ExAws.SQS.receive_message(receive_messages_opts)
@@ -97,8 +97,8 @@ defmodule BroadwaySQS.ExAwsClient do
     IO.warn("Unable to fetch events from AWS. Reason: #{inspect(reason)}")
   end
 
-  defp put_max_number_of_messages(receive_messages_opts, total_demand) do
-    max_number_of_messages = min(total_demand, receive_messages_opts[:max_number_of_messages])
+  defp put_max_number_of_messages(receive_messages_opts, demand) do
+    max_number_of_messages = min(demand, receive_messages_opts[:max_number_of_messages])
     Keyword.put(receive_messages_opts, :max_number_of_messages, max_number_of_messages)
   end
 

--- a/lib/broadway_sqs/sqs_client.ex
+++ b/lib/broadway_sqs/sqs_client.ex
@@ -7,14 +7,12 @@ defmodule BroadwaySQS.SQSClient do
 
   """
 
-  @type received_messages :: [Broadway.Message.t()]
+  alias Broadway.Message
 
-  @type message_receipt :: %{id: binary, receipt_handle: binary}
-
-  @type message_receipts :: [message_receipt]
+  @type messages :: [Message.t()]
 
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
   @callback receive_messages(total_demand :: pos_integer, opts :: any, ack_module :: module) ::
-              received_messages
-  @callback delete_messages(message_receipts, opts :: any) :: no_return
+              messages
+  @callback delete_messages(messages, opts :: any) :: no_return
 end

--- a/lib/broadway_sqs/sqs_client.ex
+++ b/lib/broadway_sqs/sqs_client.ex
@@ -1,9 +1,9 @@
 defmodule BroadwaySQS.SQSClient do
   @moduledoc """
   A generic behaviour to implement SQS CLients for `BroadwaySQS.SQSProducer`.
-  This module defines callbacks to normalize options, receive message batches and
-  acknowledge/delete messages from a SQS queue. Modules that implement this behaviour
-  should be passed as the `:sqs_client` option from `BroadwaySQS.SQSProducer`.
+  This module defines callbacks to normalize options and receive message
+  from a SQS queue. Modules that implement this behaviour should be passed
+  as the `:sqs_client` option from `BroadwaySQS.SQSProducer`.
 
   """
 
@@ -12,6 +12,5 @@ defmodule BroadwaySQS.SQSClient do
   @type messages :: [Message.t()]
 
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
-  @callback receive_messages(demand :: pos_integer, opts :: any, ack_module :: module) :: messages
-  @callback delete_messages(messages, opts :: any) :: no_return
+  @callback receive_messages(demand :: pos_integer, opts :: any) :: messages
 end

--- a/lib/broadway_sqs/sqs_client.ex
+++ b/lib/broadway_sqs/sqs_client.ex
@@ -12,7 +12,6 @@ defmodule BroadwaySQS.SQSClient do
   @type messages :: [Message.t()]
 
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
-  @callback receive_messages(total_demand :: pos_integer, opts :: any, ack_module :: module) ::
-              messages
+  @callback receive_messages(demand :: pos_integer, opts :: any, ack_module :: module) :: messages
   @callback delete_messages(messages, opts :: any) :: no_return
 end

--- a/lib/broadway_sqs/sqs_producer.ex
+++ b/lib/broadway_sqs/sqs_producer.ex
@@ -108,13 +108,7 @@ defmodule BroadwaySQS.SQSProducer do
 
   defp delete_messages_from_sqs(messages) do
     [%Message{acknowledger: {_, %{sqs_client: {client, opts}}}} | _] = messages
-    receipts = Enum.map(messages, &extract_message_receipt/1)
-    client.delete_messages(receipts, opts)
-  end
-
-  defp extract_message_receipt(message) do
-    {_, %{receipt: receipt}} = message.acknowledger
-    receipt
+    client.delete_messages(messages, opts)
   end
 
   defp schedule_receive_messages(interval) do

--- a/lib/broadway_sqs/sqs_producer.ex
+++ b/lib/broadway_sqs/sqs_producer.ex
@@ -34,11 +34,6 @@ defmodule BroadwaySQS.SQSProducer do
 
   use GenStage
 
-  alias Broadway.{Message, Acknowledger}
-
-  @behaviour Acknowledger
-
-  @max_num_messages_allowed_by_aws 10
   @default_receive_interval 5000
 
   @impl true
@@ -76,13 +71,6 @@ defmodule BroadwaySQS.SQSProducer do
     {:noreply, [], state}
   end
 
-  @impl Acknowledger
-  def ack(successful, _failed) do
-    successful
-    |> Enum.chunk_every(@max_num_messages_allowed_by_aws)
-    |> Enum.each(&delete_messages_from_sqs/1)
-  end
-
   def handle_receive_messages(%{receive_timer: nil, demand: demand} = state) when demand > 0 do
     messages = receive_messages_from_sqs(state, demand)
     new_demand = demand - length(messages)
@@ -103,12 +91,7 @@ defmodule BroadwaySQS.SQSProducer do
 
   defp receive_messages_from_sqs(state, total_demand) do
     %{sqs_client: {client, opts}} = state
-    client.receive_messages(total_demand, opts, __MODULE__)
-  end
-
-  defp delete_messages_from_sqs(messages) do
-    [%Message{acknowledger: {_, %{sqs_client: {client, opts}}}} | _] = messages
-    client.delete_messages(messages, opts)
+    client.receive_messages(total_demand, opts)
   end
 
   defp schedule_receive_messages(interval) do

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -233,8 +233,8 @@ defmodule BroadwaySQS.ExAwsClientTest do
 
       ExAwsClient.delete_messages(
         [
-          %{id: "1", receipt_handle: "abc"},
-          %{id: "2", receipt_handle: "def"}
+          %Message{acknowledger: {:a_module, %{receipt: %{id: "1", receipt_handle: "abc"}}}},
+          %Message{acknowledger: {:a_module, %{receipt: %{id: "2", receipt_handle: "def"}}}}
         ],
         opts
       )
@@ -259,7 +259,9 @@ defmodule BroadwaySQS.ExAwsClientTest do
 
       {:ok, opts} = Keyword.put(base_opts, :config, config) |> ExAwsClient.init()
 
-      ExAwsClient.delete_messages([%{id: "1", receipt_handle: "abc"}], opts)
+      message = %Message{acknowledger: {:a_module, %{receipt: %{id: "1", receipt_handle: "abc"}}}}
+
+      ExAwsClient.delete_messages([message], opts)
 
       assert_received {:http_request_called, %{url: url}}
       assert url == "http://localhost:9324/my_queue"

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -152,17 +152,15 @@ defmodule BroadwaySQS.ExAwsClientTest do
                  {ExAwsClient,
                   %{
                     receipt: %{id: "Id_1", receipt_handle: "ReceiptHandle_1"},
-                    sqs_client:
-                      {ExAwsClient,
-                       %{
-                         config: [
-                           http_client: FakeHttpClient,
-                           access_key_id: "FAKE_ID",
-                           secret_access_key: "FAKE_KEY"
-                         ],
-                         queue_name: "my_queue",
-                         receive_messages_opts: [max_number_of_messages: 10]
-                       }}
+                    sqs_client_opts: %{
+                      config: [
+                        http_client: FakeHttpClient,
+                        access_key_id: "FAKE_ID",
+                        secret_access_key: "FAKE_KEY"
+                      ],
+                      queue_name: "my_queue",
+                      receive_messages_opts: [max_number_of_messages: 10]
+                    }
                   }},
                data: "Message 1",
                processor_pid: nil,
@@ -230,8 +228,8 @@ defmodule BroadwaySQS.ExAwsClientTest do
 
     test "send a SQS/DeleteMessageBatch request", %{opts: base_opts} do
       {:ok, opts} = ExAwsClient.init(base_opts)
-      ack_data_1 = %{sqs_client: {ExAwsClient, opts}, receipt: %{id: "1", receipt_handle: "abc"}}
-      ack_data_2 = %{sqs_client: {ExAwsClient, opts}, receipt: %{id: "2", receipt_handle: "def"}}
+      ack_data_1 = %{sqs_client_opts: opts, receipt: %{id: "1", receipt_handle: "abc"}}
+      ack_data_2 = %{sqs_client_opts: opts, receipt: %{id: "2", receipt_handle: "def"}}
 
       ExAwsClient.ack(
         [
@@ -261,7 +259,7 @@ defmodule BroadwaySQS.ExAwsClientTest do
 
       {:ok, opts} = Keyword.put(base_opts, :config, config) |> ExAwsClient.init()
 
-      ack_data = %{sqs_client: {ExAwsClient, opts}, receipt: %{id: "1", receipt_handle: "abc"}}
+      ack_data = %{sqs_client_opts: opts, receipt: %{id: "1", receipt_handle: "abc"}}
       message = %Message{acknowledger: {ExAwsClient, ack_data}}
 
       ExAwsClient.ack([message], [])


### PR DESCRIPTION
SQSProducer shouldn't know anything about message receipts. It's up to the client to decide how to use them in order to remove messages from the queue.