### PR TITLE
better error handling

### DIFF
--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -70,6 +70,7 @@ defmodule BroadwaySQS.ExAwsClient do
 
   defp wrap_received_messages({:error, reason}, _) do
     Logger.error("Unable to fetch events from AWS. Reason: #{inspect(reason)}")
+    []
   end
 
   defp put_max_number_of_messages(receive_messages_opts, demand) do


### PR DESCRIPTION
The Logger.error call returns an :ok atom, but the downstream
BroadwaySQS.Producer.handle_receive_messages/1 expects a list
it can call `length/1` on

The net result is that if bad credentials are given in the
config of a module that uses Broadway, then the GenServer keeps
running instead of terminating just because one of the calls to
AWS gives an error. It may be temporary. Returning an empty list
seems reasonable