### PR TITLE
Allow SQS Visibility Timeout to be an option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ erl_crash.dump
 broadway_sqs-*.tar
 
 .elixir_ls
+.tool-versions

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -99,24 +99,24 @@ defmodule BroadwaySQS.ExAwsClient do
     do: validation_error(:wait_time_seconds, "a non negative integer", value)
 
   defp validate_option(:max_number_of_messages, value)
-       when value not in 1..@max_num_messages_allowed_by_aws,
-       do:
-         validation_error(
-           :max_number_of_messages,
-           "an integer between 1 and #{@max_num_messages_allowed_by_aws}",
-           value
-         )
+       when value not in 1..@max_num_messages_allowed_by_aws do
+    validation_error(
+      :max_number_of_messages,
+      "an integer between 1 and #{@max_num_messages_allowed_by_aws}",
+      value
+    )
+  end
 
   defp validate_option(:visibility_timeout, nil), do: {:ok, nil}
 
   defp validate_option(:visibility_timeout, value)
-       when value not in 0..@max_visibility_timeout_allowed_by_aws_in_seconds,
-       do:
-         validation_error(
-           :visibility_timeout,
-           "an integer between 0 and #{@max_visibility_timeout_allowed_by_aws_in_seconds}",
-           value
-         )
+       when value not in 0..@max_visibility_timeout_allowed_by_aws_in_seconds do
+    validation_error(
+      :visibility_timeout,
+      "an integer between 0 and #{@max_visibility_timeout_allowed_by_aws_in_seconds}",
+      value
+    )
+  end
 
   defp validate_option(_, value), do: {:ok, value}
 

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -128,8 +128,7 @@ defmodule BroadwaySQS.ExAwsClient do
     with {:ok, wait_time_seconds} <- validate(opts, :wait_time_seconds),
          {:ok, max_number_of_messages} <-
            validate(opts, :max_number_of_messages, @default_max_number_of_messages),
-         {:ok, visibility_timeout} <-
-           validate(opts, :visibility_timeout) do
+         {:ok, visibility_timeout} <- validate(opts, :visibility_timeout) do
       wait_time_seconds_opt =
         if wait_time_seconds, do: [wait_time_seconds: wait_time_seconds], else: []
 

--- a/lib/broadway_sqs/producer.ex
+++ b/lib/broadway_sqs/producer.ex
@@ -11,6 +11,10 @@ defmodule BroadwaySQS.Producer do
       allowed by AWS. Default is `10`.
     * `:wait_time_seconds` - Optional. The duration (in seconds) for which the call waits
       for a message to arrive in the queue before returning.
+    * `:visibility_timeout` - Optional. The time period (in seconds) that a message will
+      remain _invisible_ to other consumers whilst still on the queue and not acknowledged.
+      This is passed to SQS when the message (or messages) are read.
+      This value must be between 0 and 43200 (12 hours).
     * `:config` - Optional. A set of options that overrides the default ExAws configuration
       options. The most commonly used options are: `:access_key_id`, `:secret_access_key`,
       `:scheme`, `:region` and `:port`. For a complete list of configuration options and

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -97,18 +97,18 @@ defmodule BroadwaySQS.ExAwsClientTest do
       {:error, message} = opts |> Keyword.put(:max_number_of_messages, 0) |> ExAwsClient.init()
 
       assert message ==
-               "expected :max_number_of_messages to be a integer between 1 and 10, got: 0"
+               "expected :max_number_of_messages to be an integer between 1 and 10, got: 0"
 
       {:error, message} = opts |> Keyword.put(:max_number_of_messages, 11) |> ExAwsClient.init()
 
       assert message ==
-               "expected :max_number_of_messages to be a integer between 1 and 10, got: 11"
+               "expected :max_number_of_messages to be an integer between 1 and 10, got: 11"
 
       {:error, message} =
         opts |> Keyword.put(:max_number_of_messages, :an_atom) |> ExAwsClient.init()
 
       assert message ==
-               "expected :max_number_of_messages to be a integer between 1 and 10, got: :an_atom"
+               "expected :max_number_of_messages to be an integer between 1 and 10, got: :an_atom"
     end
 
     test ":config is optional with default value []" do
@@ -126,6 +126,64 @@ defmodule BroadwaySQS.ExAwsClientTest do
       config = :an_atom
       {:error, message} = opts |> Keyword.put(:config, config) |> ExAwsClient.init()
       assert message == "expected :config to be a keyword list, got: :an_atom"
+    end
+
+    test ":visibility_timeout should be a non negative integer" do
+      opts = [queue_name: "my_queue"]
+
+      {:ok, result} = opts |> Keyword.put(:visibility_timeout, 0) |> ExAwsClient.init()
+      assert result.receive_messages_opts[:visibility_timeout] == 0
+
+      {:ok, result} = opts |> Keyword.put(:visibility_timeout, 256) |> ExAwsClient.init()
+      assert result.receive_messages_opts[:visibility_timeout] == 256
+
+      {:error, message} = opts |> Keyword.put(:visibility_timeout, -1) |> ExAwsClient.init()
+
+      assert message ==
+               "expected :visibility_timeout to be an integer between 0 and 43200, got: -1"
+
+      {:error, message} = opts |> Keyword.put(:visibility_timeout, :an_atom) |> ExAwsClient.init()
+
+      assert message ==
+               "expected :visibility_timeout to be an integer between 0 and 43200, got: :an_atom"
+    end
+
+    test ":visibility_timeout is optional without default value" do
+      {:ok, result} = ExAwsClient.init(queue_name: "my_queue")
+
+      refute Keyword.has_key?(result.receive_messages_opts, :visibility_timeout)
+    end
+
+    test ":visibility_timeout should be an integer between 0 seconds and 12 hours" do
+      opts = [queue_name: "my_queue"]
+
+      {:ok, result} = opts |> Keyword.put(:visibility_timeout, 0) |> ExAwsClient.init()
+      assert result.receive_messages_opts[:visibility_timeout] == 0
+
+      max_visibility_timeout = 12 * 60 * 60
+
+      {:ok, result} =
+        opts |> Keyword.put(:visibility_timeout, max_visibility_timeout) |> ExAwsClient.init()
+
+      assert result.receive_messages_opts[:visibility_timeout] == max_visibility_timeout
+
+      {:error, message} = opts |> Keyword.put(:visibility_timeout, -1) |> ExAwsClient.init()
+
+      assert message ==
+               "expected :visibility_timeout to be an integer between 0 and 43200, got: -1"
+
+      one_day_in_seconds = 24 * 60 * 60
+
+      {:error, message} =
+        opts |> Keyword.put(:visibility_timeout, one_day_in_seconds) |> ExAwsClient.init()
+
+      assert message ==
+               "expected :visibility_timeout to be an integer between 0 and 43200, got: 86400"
+
+      {:error, message} = opts |> Keyword.put(:visibility_timeout, :an_atom) |> ExAwsClient.init()
+
+      assert message ==
+               "expected :visibility_timeout to be an integer between 0 and 43200, got: :an_atom"
     end
   end
 


### PR DESCRIPTION
To allow the consumer from SQS to potentially override the visibility timeout set on the queue, each message read from the queue can set it upon the read action.

I ultimately am looking at how additionally I could set this on each read at runtime to cater for a slow running consumer but without setting a very high value on the queue or in this option. This will allow a kind of "keep-alive" for a message being worked upon. This is facilitated via [this](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html) call on the AWS API and I think this is supported on the `ExAws.SQS` client.