### PR TITLE
Provide message receipts to Broadway handlers

### DIFF
--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -43,15 +43,13 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl true
-  def receipt(%Message{acknowledger: {_, _, receipt}}) when is_map(receipt) do
-    if Map.has_key?(receipt, :receipt) do
-      {:ok, Map.fetch!(receipt, :receipt)}
-    else
-      {:error, :receipt_not_found}
-    end
+  def receipt(%Message{acknowledger: {_, _, %{receipt: receipt}}}) do
+    {:ok, receipt}
   end
 
-  def receipt(%Message{acknowledger: {_, _, nil}}), do: {:error, :receipt_not_found}
+  def receipt(_) do
+    {:error, :receipt_not_found}
+  end
 
   @impl true
   def ack(ack_ref, successful, _failed) do

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -43,6 +43,11 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl true
+  def receipt(%Message{acknowledger: {_, _, receipt}}) do
+    {:ok, receipt}
+  end
+
+  @impl true
   def ack(ack_ref, successful, _failed) do
     successful
     |> Enum.chunk_every(@max_num_messages_allowed_by_aws)

--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -43,9 +43,15 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl true
-  def receipt(%Message{acknowledger: {_, _, receipt}}) do
-    {:ok, receipt}
+  def receipt(%Message{acknowledger: {_, _, receipt}}) when is_map(receipt) do
+    if Map.has_key?(receipt, :receipt) do
+      {:ok, Map.fetch!(receipt, :receipt)}
+    else
+      {:error, :receipt_not_found}
+    end
   end
+
+  def receipt(%Message{acknowledger: {_, _, nil}}), do: {:error, :receipt_not_found}
 
   @impl true
   def ack(ack_ref, successful, _failed) do

--- a/lib/broadway_sqs/producer.ex
+++ b/lib/broadway_sqs/producer.ex
@@ -109,6 +109,15 @@ defmodule BroadwaySQS.Producer do
     {:noreply, [], state}
   end
 
+  @doc """
+  Provide the message receipt (if possible) to allow the caller to use it
+  directly in their code.
+  """
+  @spec receipt(Broadway.Message.t()) :: any()
+  def receipt(%Broadway.Message{acknowledger: {client, _, _}} = message) do
+    client.receipt(message)
+  end
+
   defp receive_messages_from_sqs(state, total_demand) do
     %{sqs_client: {client, opts}} = state
     client.receive_messages(total_demand, opts)

--- a/lib/broadway_sqs/producer.ex
+++ b/lib/broadway_sqs/producer.ex
@@ -113,7 +113,10 @@ defmodule BroadwaySQS.Producer do
   Provide the message receipt (if possible) to allow the caller to use it
   directly in their code.
   """
-  @spec receipt(Broadway.Message.t()) :: any()
+  @spec receipt(Broadway.Message.t()) ::
+          {:ok, receipt :: any()}
+          | {:error, :incompatible_producer}
+          | {:error, :receipt_not_found}
   def receipt(%Broadway.Message{acknowledger: {client, _, _}} = message) do
     client.receipt(message)
   end

--- a/lib/broadway_sqs/sqs_client.ex
+++ b/lib/broadway_sqs/sqs_client.ex
@@ -10,7 +10,10 @@ defmodule BroadwaySQS.SQSClient do
   alias Broadway.Message
 
   @type messages :: [Message.t()]
+  @type receipt :: map()
 
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
   @callback receive_messages(demand :: pos_integer, opts :: any) :: messages
+  @callback receipt(message :: Message.t()) ::
+              {:ok, receipt :: receipt()} | {:error, :incompatible_producer}
 end

--- a/lib/broadway_sqs/sqs_client.ex
+++ b/lib/broadway_sqs/sqs_client.ex
@@ -10,7 +10,7 @@ defmodule BroadwaySQS.SQSClient do
   alias Broadway.Message
 
   @type messages :: [Message.t()]
-  @type receipt :: map()
+  @type receipt :: any()
 
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
   @callback receive_messages(demand :: pos_integer, opts :: any) :: messages

--- a/lib/broadway_sqs/sqs_client.ex
+++ b/lib/broadway_sqs/sqs_client.ex
@@ -15,5 +15,7 @@ defmodule BroadwaySQS.SQSClient do
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
   @callback receive_messages(demand :: pos_integer, opts :: any) :: messages
   @callback receipt(message :: Message.t()) ::
-              {:ok, receipt :: receipt()} | {:error, :incompatible_producer}
+              {:ok, receipt :: receipt()}
+              | {:error, :incompatible_producer}
+              | {:error, :receipt_not_found}
 end

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -353,17 +353,21 @@ defmodule BroadwaySQS.ExAwsClientTest do
 
     test "obtain the correct message receipts", %{opts: base_opts} do
       {:ok, opts} = ExAwsClient.init(base_opts)
-      messages = ExAwsClient.receive_messages(10, opts)
+      [msg | _] = ExAwsClient.receive_messages(10, opts)
 
-      messages
-      |> Enum.with_index(1)
-      |> Enum.map(fn
-        {msg, index} ->
-          {:ok, %{receipt: %{id: id, receipt_handle: handle}}} = ExAwsClient.receipt(msg)
+      {:ok, %{id: id, receipt_handle: handle}} = ExAwsClient.receipt(msg)
 
-          assert id == "Id_#{index}"
-          assert(handle == "ReceiptHandle_#{index}")
-      end)
+      assert id == "Id_1"
+      assert handle == "ReceiptHandle_1"
+    end
+
+    test "deal with error case", %{opts: base_opts} do
+      {:ok, opts} = ExAwsClient.init(base_opts)
+      message = %Message{acknowledger: {ExAwsClient, opts.ack_ref, nil}, data: nil}
+
+      {:error, e} = ExAwsClient.receipt(message)
+
+      assert e == :receipt_not_found
     end
   end
 end

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -336,4 +336,34 @@ defmodule BroadwaySQS.ExAwsClientTest do
       assert url == "http://localhost:9324/my_queue"
     end
   end
+
+  describe "message receipt provision" do
+    setup do
+      %{
+        opts: [
+          queue_name: "my_queue",
+          config: [
+            http_client: FakeHttpClient,
+            access_key_id: "FAKE_ID",
+            secret_access_key: "FAKE_KEY"
+          ]
+        ]
+      }
+    end
+
+    test "obtain the correct message receipts", %{opts: base_opts} do
+      {:ok, opts} = ExAwsClient.init(base_opts)
+      messages = ExAwsClient.receive_messages(10, opts)
+
+      messages
+      |> Enum.with_index(1)
+      |> Enum.map(fn
+        {msg, index} ->
+          {:ok, %{receipt: %{id: id, receipt_handle: handle}}} = ExAwsClient.receipt(msg)
+
+          assert id == "Id_#{index}"
+          assert(handle == "ReceiptHandle_#{index}")
+      end)
+    end
+  end
 end

--- a/test/broadway_sqs/producer_test.exs
+++ b/test/broadway_sqs/producer_test.exs
@@ -55,8 +55,7 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
     use Broadway
 
     def handle_message(_, message, %{test_pid: test_pid}) do
-      send(test_pid, {:message_handled, message.data})
-      send(test_pid, {:handled_message, message})
+      send(test_pid, {:message_handled, message.data, message})
       message
     end
 
@@ -84,7 +83,7 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
     assert_receive {:messages_received, 5}
 
     for msg <- 1..5 do
-      assert_receive {:message_handled, ^msg}
+      assert_receive {:message_handled, ^msg, _}
     end
 
     stop_broadway(pid)
@@ -98,19 +97,19 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
     assert_receive {:messages_received, 10}
 
     for msg <- 1..10 do
-      assert_receive {:message_handled, ^msg}
+      assert_receive {:message_handled, ^msg, _}
     end
 
     assert_receive {:messages_received, 5}
 
     for msg <- 11..15 do
-      assert_receive {:message_handled, ^msg}
+      assert_receive {:message_handled, ^msg, _}
     end
 
     assert_receive {:messages_received, 5}
 
     for msg <- 16..20 do
-      assert_receive {:message_handled, ^msg}
+      assert_receive {:message_handled, ^msg, _}
     end
 
     assert_receive {:messages_received, 0}
@@ -124,15 +123,15 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
 
     MessageServer.push_messages(message_server, [13])
     assert_receive {:messages_received, 1}
-    assert_receive {:message_handled, 13}
+    assert_receive {:message_handled, 13, _}
 
     assert_receive {:messages_received, 0}
-    refute_receive {:message_handled, _}
+    refute_receive {:message_handled, _, _}
 
     MessageServer.push_messages(message_server, [14, 15])
     assert_receive {:messages_received, 2}
-    assert_receive {:message_handled, 14}
-    assert_receive {:message_handled, 15}
+    assert_receive {:message_handled, 14, _}
+    assert_receive {:message_handled, 15, _}
 
     stop_broadway(pid)
   end
@@ -155,7 +154,7 @@ defmodule BroadwaySQS.BroadwaySQS.ProducerTest do
 
     MessageServer.push_messages(message_server, 1..1)
 
-    assert_receive {:handled_message, msg}
+    assert_receive {:message_handled, _, msg}
 
     assert BroadwaySQS.Producer.receipt(msg) == {:error, :incompatible_producer}
 


### PR DESCRIPTION
Closes #10

Allows the recipient of messages to get hold of the message receipt
which facilitates usage against the SQS service. For example, this
could then be used to keep-alive the message by altering the message
visibility timeout.