### PR TITLE
Add extra message information to the metadata field

### DIFF
--- a/lib/broadway_sqs/producer.ex
+++ b/lib/broadway_sqs/producer.ex
@@ -15,6 +15,16 @@ defmodule BroadwaySQS.Producer do
       remain _invisible_ to other consumers whilst still on the queue and not acknowledged.
       This is passed to SQS when the message (or messages) are read.
       This value must be between 0 and 43200 (12 hours).
+    * `:attribute_names` - A list containing the names of attributes that should be
+      attached to the response and appended to the `metadata` field of the message.
+      Supported values are `:sender_id`, `:sent_timestamp`, `:approximate_receive_count`,
+      `:approximate_first_receive_timestamp`, `:wait_time_seconds` and
+      `:receive_message_wait_time_seconds`. You can also use `:all` instead of the list
+      if you want to retrieve all attributes.
+    * `:message_attribute_names` - A list containing the names of custom message attributes
+      that should be attached to the response and appended to the `metadata` field of the
+      message. You can also use `:all` instead of the list if you want to retrieve all
+      attributes.
     * `:config` - Optional. A set of options that overrides the default ExAws configuration
       options. The most commonly used options are: `:access_key_id`, `:secret_access_key`,
       `:scheme`, `:region` and `:port`. For a complete list of configuration options and
@@ -50,21 +60,9 @@ defmodule BroadwaySQS.Producer do
   The above configuration will set up a producer that continuously receives
   messages from `"my_queue"` and sends them downstream.
 
-  If you need to access the SQS message receipt while processing a
-  `Broadway.Message`, you can invoke `receipt/1`.
+  For a complete guide on using Broadway with Amazon SQS, please see the
+  [Amazon SQS Guide](https://hexdocs.pm/broadway/amazon-sqs.html).
   """
-
-  @doc """
-  Provide the message receipt (if possible) to allow the caller to use it
-  directly in their code.
-  """
-  @spec receipt(Broadway.Message.t()) ::
-          {:ok, receipt :: any()}
-          | {:error, :incompatible_producer}
-          | {:error, :receipt_not_found}
-  def receipt(%Broadway.Message{acknowledger: {client, _, _}} = message) do
-    client.receipt(message)
-  end
 
   use GenStage
 

--- a/lib/broadway_sqs/sqs_client.ex
+++ b/lib/broadway_sqs/sqs_client.ex
@@ -10,12 +10,7 @@ defmodule BroadwaySQS.SQSClient do
   alias Broadway.Message
 
   @type messages :: [Message.t()]
-  @type receipt :: any()
 
   @callback init(opts :: any) :: {:ok, normalized_opts :: any} | {:error, message :: binary}
   @callback receive_messages(demand :: pos_integer, opts :: any) :: messages
-  @callback receipt(message :: Message.t()) ::
-              {:ok, receipt :: receipt()}
-              | {:error, :incompatible_producer}
-              | {:error, :receipt_not_found}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule BroadwaySqs.MixProject do
 
   defp deps do
     [
-      {:broadway, "~> 0.1.0"},
+      {:broadway, git: "https://github.com/plataformatec/broadway.git"},
       {:ex_aws_sqs, "~> 2.0"},
       {:hackney, "~> 1.9", only: [:dev]},
       {:sweet_xml, "~> 0.6"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "broadway": {:hex, :broadway, "0.1.0", "e21ccf0db6175fef890ea51fbd3eb44f171657f8a04e34a1c2b08fdb4a3476b3", [:mix], [{:gen_stage, "~> 0.14", [hex: :gen_stage, repo: "hexpm", optional: false]}], "hexpm"},
+  "broadway": {:git, "https://github.com/plataformatec/broadway.git", "89e308b4f9d4f511f41169e167f84ddd46b650eb", []},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "ex_aws": {:hex, :ex_aws, "2.0.2", "8df2f96f58624a399abe5a0ce26db648ee848aca6393b9c65c939ece9ac07bfa", [:mix], [{:configparser_ex, "~> 2.0", [hex: :configparser_ex, repo: "hexpm", optional: true]}, {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9", [hex: :hackney, repo: "hexpm", optional: true]}, {:jsx, "~> 2.8", [hex: :jsx, repo: "hexpm", optional: true]}, {:poison, ">= 1.2.0", [hex: :poison, repo: "hexpm", optional: true]}, {:sweet_xml, "~> 0.6", [hex: :sweet_xml, repo: "hexpm", optional: true]}, {:xml_builder, "~> 0.1.0", [hex: :xml_builder, repo: "hexpm", optional: true]}], "hexpm"},

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -17,7 +17,23 @@ defmodule BroadwaySQS.ExAwsClientTest do
           <Message>
             <MessageId>Id_1</MessageId>
             <ReceiptHandle>ReceiptHandle_1</ReceiptHandle>
+            <MD5OfBody>fake_md5</MD5OfBody>
             <Body>Message 1</Body>
+            <Attribute>
+              <Name>SenderId</Name>
+              <Value>13</Value>
+            </Attribute>
+            <Attribute>
+              <Name>ApproximateReceiveCount</Name>
+              <Value>5</Value>
+            </Attribute>
+            <MessageAttribute>
+              <Name>TestStringAttribute</Name>
+              <Value>
+                <StringValue>Test</StringValue>
+                <DataType>String</DataType>
+              </Value>
+            </MessageAttribute>
           </Message>
           <Message>
             <MessageId>Id_2</MessageId>
@@ -64,6 +80,61 @@ defmodule BroadwaySQS.ExAwsClientTest do
 
       {:ok, %{queue_name: queue_name}} = ExAwsClient.init(queue_name: "my_queue")
       assert queue_name == "my_queue"
+    end
+
+    test ":attribute_names is optional without default value" do
+      {:ok, result} = ExAwsClient.init(queue_name: "my_queue")
+
+      refute Keyword.has_key?(result.receive_messages_opts, :attribute_names)
+    end
+
+    test ":attribute_names should be a list containing any of the supported attributes" do
+      all_attribute_names = [
+        :sender_id,
+        :sent_timestamp,
+        :approximate_receive_count,
+        :approximate_first_receive_timestamp,
+        :wait_time_seconds,
+        :receive_message_wait_time_seconds
+      ]
+
+      {:ok, result} =
+        ExAwsClient.init(queue_name: "my_queue", attribute_names: all_attribute_names)
+
+      assert result.receive_messages_opts[:attribute_names] == all_attribute_names
+
+      attribute_names = [:approximate_receive_count, :unsupported]
+
+      {:error, message} =
+        ExAwsClient.init(queue_name: "my_queue", attribute_names: attribute_names)
+
+      assert message ==
+               "expected :attribute_names to be :all or a list containing any of " <>
+                 inspect(all_attribute_names) <>
+                 ", got: [:approximate_receive_count, :unsupported]"
+    end
+
+    test ":message_attribute_names is optional without default value" do
+      {:ok, result} = ExAwsClient.init(queue_name: "my_queue")
+
+      refute Keyword.has_key?(result.receive_messages_opts, :message_attribute_names)
+    end
+
+    test ":message_attribute_names should be a list of non empty strings" do
+      {:ok, result} =
+        ExAwsClient.init(queue_name: "my_queue", message_attribute_names: ["attr_1", "attr_2"])
+
+      assert result.receive_messages_opts[:message_attribute_names] == ["attr_1", "attr_2"]
+
+      {:error, message} =
+        ExAwsClient.init(
+          queue_name: "my_queue",
+          message_attribute_names: ["attr_1", :not_a_string]
+        )
+
+      assert message ==
+               "expected :message_attribute_names to be :all or a list of non empty strings" <>
+                 ", got: [\"attr_1\", :not_a_string]"
     end
 
     test ":wait_time_seconds is optional without default value" do
@@ -215,15 +286,50 @@ defmodule BroadwaySQS.ExAwsClientTest do
       {:ok, opts} = ExAwsClient.init(base_opts)
       [message1, message2] = ExAwsClient.receive_messages(10, opts)
 
-      assert message1 == %Message{
-               acknowledger:
-                 {ExAwsClient, opts.ack_ref,
-                  %{receipt: %{id: "Id_1", receipt_handle: "ReceiptHandle_1"}}},
-               data: "Message 1",
-               batcher: :default
+      assert message1.data == "Message 1"
+      assert message2.data == "Message 2"
+
+      assert message1.acknowledger ==
+               {ExAwsClient, opts.ack_ref,
+                %{receipt: %{id: "Id_1", receipt_handle: "ReceiptHandle_1"}}}
+    end
+
+    test "add message_id, receipt_handle and md5_of_body to metadata", %{opts: base_opts} do
+      {:ok, opts} = ExAwsClient.init(base_opts)
+      [%{metadata: metadata} | _] = ExAwsClient.receive_messages(10, opts)
+
+      assert metadata.message_id == "Id_1"
+      assert metadata.receipt_handle == "ReceiptHandle_1"
+      assert metadata.md5_of_body == "fake_md5"
+    end
+
+    test "add attributes to metadata", %{opts: base_opts} do
+      {:ok, opts} = Keyword.put(base_opts, :attribute_names, :all) |> ExAwsClient.init()
+
+      [%{metadata: metadata_1}, %{metadata: metadata_2} | _] =
+        ExAwsClient.receive_messages(10, opts)
+
+      assert metadata_1.attributes == %{"sender_id" => 13, "approximate_receive_count" => 5}
+      assert metadata_2.attributes == []
+    end
+
+    test "add message_attributes to metadata", %{opts: base_opts} do
+      {:ok, opts} = Keyword.put(base_opts, :message_attribute_names, :all) |> ExAwsClient.init()
+
+      [%{metadata: metadata_1}, %{metadata: metadata_2} | _] =
+        ExAwsClient.receive_messages(10, opts)
+
+      assert metadata_1.message_attributes == %{
+               "TestStringAttribute" => %{
+                 name: "TestStringAttribute",
+                 data_type: "String",
+                 string_value: "Test",
+                 binary_value: "",
+                 value: "Test"
+               }
              }
 
-      assert message2.data == "Message 2"
+      assert metadata_2.message_attributes == []
     end
 
     test "if the request fails, returns an empty list and log the error", %{opts: base_opts} do
@@ -334,40 +440,6 @@ defmodule BroadwaySQS.ExAwsClientTest do
 
       assert_received {:http_request_called, %{url: url}}
       assert url == "http://localhost:9324/my_queue"
-    end
-  end
-
-  describe "message receipt provision" do
-    setup do
-      %{
-        opts: [
-          queue_name: "my_queue",
-          config: [
-            http_client: FakeHttpClient,
-            access_key_id: "FAKE_ID",
-            secret_access_key: "FAKE_KEY"
-          ]
-        ]
-      }
-    end
-
-    test "obtain the correct message receipts", %{opts: base_opts} do
-      {:ok, opts} = ExAwsClient.init(base_opts)
-      [msg | _] = ExAwsClient.receive_messages(10, opts)
-
-      {:ok, %{id: id, receipt_handle: handle}} = ExAwsClient.receipt(msg)
-
-      assert id == "Id_1"
-      assert handle == "ReceiptHandle_1"
-    end
-
-    test "deal with error case", %{opts: base_opts} do
-      {:ok, opts} = ExAwsClient.init(base_opts)
-      message = %Message{acknowledger: {ExAwsClient, opts.ack_ref, nil}, data: nil}
-
-      {:error, e} = ExAwsClient.receipt(message)
-
-      assert e == :receipt_not_found
     end
   end
 end

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -65,7 +65,7 @@ defmodule BroadwaySQS.ExAwsClientTest do
   describe "validate init options" do
     test ":queue_name is required" do
       assert ExAwsClient.init([]) ==
-               {:error, "expected :queue_name to be a non empty string, got: nil"}
+               {:error, ":queue_name is required"}
 
       assert ExAwsClient.init(queue_name: nil) ==
                {:error, "expected :queue_name to be a non empty string, got: nil"}


### PR DESCRIPTION
  * Add `message_id`, `receipt_handle` and `md5_of_body` to metadata
  * Add attributes to metadata based on the `:attribute_names` option 
  * Add message_attributes to metadata based on the `:message_attribute_names` option

Closes #14 