### PR TITLE
improving 'first look' example for saving time when making a fast POC

### DIFF
--- a/lib/broadway_sqs/producer.ex
+++ b/lib/broadway_sqs/producer.ex
@@ -50,7 +50,8 @@ defmodule BroadwaySQS.Producer do
               queue_name: "my_queue",
               config: [
                 access_key_id: "YOUR_AWS_ACCESS_KEY_ID",
-                secret_access_key: "YOUR_AWS_SECRET_ACCESS_KEY"
+                secret_access_key: "YOUR_AWS_SECRET_ACCESS_KEY",
+                region: "us-east-2"
               ]
             }
           ]


### PR DESCRIPTION
Today I decided to make a POC to try broadway using just the first look example and then I faced this issue: For default, the region for sqs is `us-east-1` (that isn't a problem, obviously) but just like the keys, queue names and secrets is important to reach the queue, region is important also.
So to save time for the future developers, I'd like to propose to see the region setted explicitly in the initial example.
What do you think?   