### PR TITLE
Add config for sending failed messages to a specified dead letter queue

### DIFF
--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -28,8 +28,14 @@ defmodule BroadwaySQS.ExAwsClient do
   def init(opts) do
     with {:ok, queue_url} <- validate(opts, :queue_url, required: true),
          {:ok, receive_messages_opts} <- validate_receive_messages_opts(opts),
+         {:ok, dead_letter_queue_url} <- validate(opts, :dead_letter_queue_url, default: ""),
          {:ok, config} <- validate(opts, :config, default: []) do
-      ack_ref = Broadway.TermStorage.put(%{queue_url: queue_url, config: config})
+      ack_ref =
+        Broadway.TermStorage.put(%{
+          queue_url: queue_url,
+          config: config,
+          dead_letter_queue_url: dead_letter_queue_url
+        })
 
       {:ok,
        %{
@@ -52,8 +58,23 @@ defmodule BroadwaySQS.ExAwsClient do
   end
 
   @impl true
-  def ack(ack_ref, successful, _failed) do
-    successful
+  def ack(ack_ref, successful, failed) do
+    opts = Broadway.TermStorage.get!(ack_ref)
+
+    to_remove =
+      case opts.dead_letter_queue_url do
+        "" ->
+          successful
+
+        _url ->
+          failed
+          |> Enum.chunk_every(@max_num_messages_allowed_by_aws)
+          |> Enum.each(fn messages -> send_messages(messages, ack_ref) end)
+
+          successful ++ failed
+      end
+
+    to_remove
     |> Enum.chunk_every(@max_num_messages_allowed_by_aws)
     |> Enum.each(fn messages -> delete_messages(messages, ack_ref) end)
   end
@@ -65,6 +86,16 @@ defmodule BroadwaySQS.ExAwsClient do
 
     opts.queue_url
     |> ExAws.SQS.delete_message_batch(receipts)
+    |> ExAws.request(opts.config)
+  end
+
+  defp send_messages(messages, ack_ref) do
+    new_messages = Enum.map(messages, &extract_failed_message/1)
+
+    opts = Broadway.TermStorage.get!(ack_ref)
+
+    opts.dead_letter_queue_url
+    |> ExAws.SQS.send_message_batch(new_messages)
     |> ExAws.request(opts.config)
   end
 
@@ -89,6 +120,16 @@ defmodule BroadwaySQS.ExAwsClient do
   defp put_max_number_of_messages(receive_messages_opts, demand) do
     max_number_of_messages = min(demand, receive_messages_opts[:max_number_of_messages])
     Keyword.put(receive_messages_opts, :max_number_of_messages, max_number_of_messages)
+  end
+
+  defp extract_failed_message(message) do
+    {:failed, reason} = message.status
+
+    [
+      id: message.metadata.message_id,
+      message_body: message.data,
+      message_attributes: [%{name: "reason", data_type: :string, value: reason}]
+    ]
   end
 
   defp extract_message_receipt(message) do
@@ -121,6 +162,9 @@ defmodule BroadwaySQS.ExAwsClient do
 
   defp validate_option(:queue_url, value) when not is_binary(value) or value == "",
     do: validation_error(:queue_url, "a non empty string", value)
+
+  defp validate_option(:dead_letter_queue_url, value) when not is_binary(value),
+    do: validation_error(:dead_letter_queue_url, "a string", value)
 
   defp validate_option(:wait_time_seconds, value) when not is_integer(value) or value < 0,
     do: validation_error(:wait_time_seconds, "a non negative integer", value)


### PR DESCRIPTION
## What this code change does
* Allows user to specify `dead_letter_queue_url` configuration option.
* Messages marked as failures will be sent to the dead-letter and deleted from the original queue from which they were received along with a message attribute `reason` with the failure reason.
* Minimal validation is included for the `dead_letter_queue_url` option: it must be a `binary` and it defaults to `""`.

## Use case
Currently, allowing failed messages to go unacknowledged allows messages received beyond the queue's "maximum receives" to fall to the dead-letter. Yay!

But that's just one way that dead-letters get used.

In the case of "poison pill" messages (as aws mentions in their [docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html) on dead-letters), some things are either outright garbage or, during handling (for one reason or another), need to have some handling issue registered immediately. These changes allow us to treat failures more actively and aggressively as something that needs to be registered and taken out of the receipt loop.

## Limitations, Improvements
* There is a happy medium: ideally the library should allow some failures to be passive (unacknowledged; received until "maximum receives") and some failures to be active (acknowledged; sent to dead-letter with reason attribute). There is filtering and further configuration that can make this happen, but I don't see a reason _not_ to start with having _some_ version of an active option (even if it's absolute).
* There should probably be an option to post to the dead-letter **without** ack-ing the message and removing from the original queue. I actually don't know if this is a valid use case; but, since it's strictly possible it's worth considering.
* I just kind of hacked this together and if there are tweaks I can make please let me know. Also happy to write the documentation if the changes are agreeable (also happy to write some tests!).