### PR TITLE
Allow all attribute names listed in the AWS docs

### DIFF
--- a/lib/broadway_sqs/ex_aws_client.ex
+++ b/lib/broadway_sqs/ex_aws_client.ex
@@ -20,8 +20,10 @@ defmodule BroadwaySQS.ExAwsClient do
     :sent_timestamp,
     :approximate_receive_count,
     :approximate_first_receive_timestamp,
-    :wait_time_seconds,
-    :receive_message_wait_time_seconds
+    :sequence_number,
+    :message_deduplication_id,
+    :message_group_id,
+    :aws_trace_header
   ]
 
   @impl true

--- a/lib/broadway_sqs/producer.ex
+++ b/lib/broadway_sqs/producer.ex
@@ -30,10 +30,18 @@ defmodule BroadwaySQS.Producer do
 
     * `:attribute_names` - A list containing the names of attributes that should be
       attached to the response and appended to the `metadata` field of the message.
-      Supported values are `:sender_id`, `:sent_timestamp`, `:approximate_receive_count`,
-      `:approximate_first_receive_timestamp`, `:wait_time_seconds` and
-      `:receive_message_wait_time_seconds`. You can also use `:all` instead of the list
-      if you want to retrieve all attributes.
+      Supported values are:
+
+      * `:sender_id`
+      * `:sent_timestamp`
+      * `:approximate_receive_count`
+      * `:approximate_first_receive_timestamp`
+      * `:sequence_number`
+      * `:message_deduplication_id`
+      * `:message_group_id`
+      * `:aws_trace_header`
+
+      You can also use `:all` instead of the list if you want to retrieve all attributes.
 
     * `:message_attribute_names` - A list containing the names of custom message attributes
       that should be attached to the response and appended to the `metadata` field of the

--- a/test/broadway_sqs/ex_aws_client_test.exs
+++ b/test/broadway_sqs/ex_aws_client_test.exs
@@ -94,8 +94,10 @@ defmodule BroadwaySQS.ExAwsClientTest do
         :sent_timestamp,
         :approximate_receive_count,
         :approximate_first_receive_timestamp,
-        :wait_time_seconds,
-        :receive_message_wait_time_seconds
+        :sequence_number,
+        :message_deduplication_id,
+        :message_group_id,
+        :aws_trace_header
       ]
 
       {:ok, result} =


### PR DESCRIPTION
In this pull request, I basically propagate the changes from https://github.com/ex-aws/ex_aws_sqs/pull/14 to this project, where the list of allowed attribute names for receiving SQS messages has been updated to match the ones documented on https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html#API_ReceiveMessage_RequestParameters.

Since `ex_aws_sqs` does not enforce the allowed attribute names, this PR can be merged and works independently of https://github.com/ex-aws/ex_aws_sqs/pull/14. The only exception is `:aws_trace_header`, which needs a special conversion rule (implemented in `ex_aws`).

As also stated in the original PR, I have removed two values (`:wait_time_seconds` & `:receive_message_wait_time_seconds`) which, to the best of my knowledge, are no message attributes. This is a breaking change for users of this library that are currently passing those options.